### PR TITLE
Fixed deleting all but one node in a isolated chain before merging.

### DIFF
--- a/src/ConveyorNode.ts
+++ b/src/ConveyorNode.ts
@@ -390,7 +390,7 @@ export function smart_merge(
             return [curr_node]
         } else if (path.includes(curr_node)) {
             return []
-        } else if (curr_node.outs.length === 0) {
+        } else if (curr_node.outs.length === 0 || curr_node.ins.length === 0) {
             return null
         }
         let excess_children = new Array()


### PR DESCRIPTION
For Sources that don't need any splitting before being merged to reach a Target, `_are_children_excess` would determine that the whole chain excluding the very root are excess. However, `merge` has the expectation that all nodes to be worked on have at least one parent, which seems to have caused #8.

This simple half liner *should* (and seems to) ensure that it will keep at least two nodes in a chain.

Fixes #8 
